### PR TITLE
refactor: Fine tuning the const Playwright to improve performance

### DIFF
--- a/docs/constants/playwright.ts
+++ b/docs/constants/playwright.ts
@@ -1,7 +1,7 @@
 // Default DIFF Pixel
 export const PLAYWRIGHT_MAX_DIFF_PIXEL_RATIO = 0.01;
 // We wait max for .5 second for mounting
-export const PLAYWRIGHT_DEFAULT_TIMEOUT = 500;
+export const PLAYWRIGHT_DEFAULT_TIMEOUT = 100;
 // We check difference > 4px
 export const PLAYWRIGHT_MAX_DIFF_PIXEL = 4;
 // Acceptable perceived color difference between the same pixel in compared images, ranging from 0 (strict) and 1 (lax). "pixelmatch" comparator computes color difference in YIQ color space


### PR DESCRIPTION
This will cause a huge improvement on the execution time of the tests.

Test does not seems to fail, apparently it works very good.

**Tests:**

avatar from 9s to 4.5s (50%)
authcode from 20-30 seconds -> 11.5 (~41%-61%)
accordion from seconds 41s-> 25s (~39%)

This is just a quality of life commit finetuning for now, to save 30 seconds each time we run the tests locally during the development.