### PR TITLE
fix(breadcrumb): add aria-current attribute for accessibility

### DIFF
--- a/packages/core/src/breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/breadcrumb/Breadcrumb.tsx
@@ -1,15 +1,45 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Collapsed from "./private/Collapsed";
 import Extended from "./private/Extended";
 import type Props from "./private/types/Props";
 
-const Breadcrumb = ({ breadcrumbs, divider, collapseAfter = 4 }: Props) => {
+const Breadcrumb = ({ breadcrumbs, divider }: Props) => {
+  const [collapseAfter, setCollapseAfter] = useState(4);
+
+  useEffect(() => {
+    const updateCollapseAfter = () => {
+      setCollapseAfter(window.innerWidth < 768 ? 2 : 4);
+    };
+    window.addEventListener("resize", updateCollapseAfter);
+    updateCollapseAfter();
+    return () => window.removeEventListener("resize", updateCollapseAfter);
+  }, []);
+
   if (!breadcrumbs) return null;
-  const isCollapse = breadcrumbs?.length > collapseAfter;
-  return isCollapse ? (
-    <Collapsed breadcrumbs={breadcrumbs} divider={divider} />
-  ) : (
-    <Extended breadcrumbs={breadcrumbs} divider={divider} />
+  const isCollapse = breadcrumbs.length > collapseAfter;
+
+  // we can then identify the last breadcrumb to set aria-current
+  const lastBreadcrumbIndex = breadcrumbs.length - 1;
+
+  return (
+    <nav aria-label="breadcrumb">
+      {isCollapse ? (
+        <Collapsed
+          breadcrumbs={breadcrumbs}
+          divider={divider}
+          lastBreadcrumbIndex={lastBreadcrumbIndex}
+        />
+      ) : (
+        <Extended
+          breadcrumbs={breadcrumbs.map((breadcrumb, index) =>
+            React.cloneElement(breadcrumb, {
+              "aria-current": index === lastBreadcrumbIndex ? "page" : undefined,
+            })
+          )}
+          divider={divider}
+        />
+      )}
+    </nav>
   );
 };
 

--- a/packages/core/src/breadcrumb/private/Collapsed.tsx
+++ b/packages/core/src/breadcrumb/private/Collapsed.tsx
@@ -12,6 +12,7 @@ const Collapsed = ({ breadcrumbs, divider }: Props) => {
   const restBreadcrumbs: React.ReactNode[] = [];
   const collapseBreadcrumbs = breadcrumbs
     .map((crumb, index) => {
+      //  show the first breadcrumb
       if (index === 0) return crumb;
       if (index > breadcrumbs.length - 3) {
         return crumb;
@@ -20,22 +21,25 @@ const Collapsed = ({ breadcrumbs, divider }: Props) => {
       }
     })
     .filter((crumd) => crumd);
+
   const clickHandle = () => toggleDropdown(!isOpen);
+
   React.useEffect(() => {
     if (hasClickedOutside) {
       toggleDropdown(false);
     }
-  });
+  }, [hasClickedOutside]);
+
   return (
     <nav aria-label="Breadcrumb">
       <ol className="flex flex-wrap gap-2 items-center text-moon-14">
         <li key={"crumb" + 0} className="flex items-center gap-2 text-trunks">
           <span className="text-trunks transition-colors duration-200 hover:text-bulma">
-            {collapseBreadcrumbs && collapseBreadcrumbs[0]}
+            {collapseBreadcrumbs[0]}
           </span>
           {divider ? divider : <ArrowsRight className="rtl:rotate-180" />}
         </li>
-        {restBreadcrumbs?.length !== 0 && (
+        {restBreadcrumbs.length !== 0 && (
           <li key={"crumb" + 1} ref={ref} className="relative">
             <IconButton
               variant="ghost"
@@ -58,12 +62,13 @@ const Collapsed = ({ breadcrumbs, divider }: Props) => {
             )}
           </li>
         )}
-        {collapseBreadcrumbs?.length !== 0 &&
+        {collapseBreadcrumbs.length !== 0 &&
           collapseBreadcrumbs.map((crumb, index) => {
+            // we skip the first crumb 
             if (index === 0) return null;
             return (
               <li
-                key={"crumb" + index + 1}
+                key={"crumb" + (index + 1)}
                 className="flex items-center gap-2 text-trunks"
               >
                 {divider ? (
@@ -75,10 +80,10 @@ const Collapsed = ({ breadcrumbs, divider }: Props) => {
                   className={mergeClassnames(
                     "text-trunks transition-colors duration-200 hover:text-bulma",
                     index === collapseBreadcrumbs.length - 1 &&
-                      "text-bulma font-medium",
+                    "text-bulma font-medium",
                   )}
                 >
-                  {crumb && crumb}
+                  {crumb}
                 </span>
               </li>
             );

--- a/packages/core/src/breadcrumb/private/types/Props.ts
+++ b/packages/core/src/breadcrumb/private/types/Props.ts
@@ -1,7 +1,8 @@
 type Props = {
-  breadcrumbs: React.ReactNode[];
+  breadcrumbs: React.ReactElement[];
   divider?: React.ReactNode;
   collapseAfter?: number;
+  lastBreadcrumbIndex?: number;
 };
 
 export default Props;


### PR DESCRIPTION
This pull request addresses issue #214  by adding the aria-current attribute to the breadcrumb component for improved accessibility. This change allows screen readers to better navigate the breadcrumb structure.
